### PR TITLE
Use UTF-8 literals for constant keys

### DIFF
--- a/src/Skylight.Protocol.Generator/Writer/Handlers/TypeMappingWriteHandler.cs
+++ b/src/Skylight.Protocol.Generator/Writer/Handlers/TypeMappingWriteHandler.cs
@@ -153,8 +153,7 @@ internal sealed class TypeMappingWriteHandler : MappingWriterHandler
 		{
 			if (typeMapping.ExtraData is not null)
 			{
-				writer.WriteLine($"writer.WriteText(\"{typeMapping.ExtraData}\");");
-				writer.WriteLine($"writer.WriteText(\"=\");");
+				writer.WriteLine($"writer.WriteBytes(\"{typeMapping.ExtraData}=\"u8);");
 				WriteText(ref context, protocol, writer, mapping, type);
 				writer.WriteLine($"writer.WriteByte(13);");
 			}

--- a/src/Skylight.Protocol.X/Skylight.Protocol.RELEASE9/Packets/Composers/Handshake/UserObjectPacketComposer.cs
+++ b/src/Skylight.Protocol.X/Skylight.Protocol.RELEASE9/Packets/Composers/Handshake/UserObjectPacketComposer.cs
@@ -13,28 +13,22 @@ internal sealed class UserObjectPacketComposer : IOutgoingPacketComposer<UserObj
 {
 	public void Compose(ref PacketWriter writer, in UserObjectOutgoingPacket packet)
 	{
-		writer.WriteText("name");
-		writer.WriteText("=");
+		writer.WriteBytes("name="u8);
 		writer.WriteText(packet.Username.ToString());
 		writer.WriteByte(13);
-		writer.WriteText("figure");
-		writer.WriteText("=");
+		writer.WriteBytes("figure="u8);
 		writer.WriteText(packet.Figure.ToString());
 		writer.WriteByte(13);
-		writer.WriteText("sex");
-		writer.WriteText("=");
+		writer.WriteBytes("sex="u8);
 		writer.WriteText(packet.Gender.ToString());
 		writer.WriteByte(13);
-		writer.WriteText("customData");
-		writer.WriteText("=");
+		writer.WriteBytes("customData="u8);
 		writer.WriteText(packet.CustomData.ToString());
 		writer.WriteByte(13);
-		writer.WriteText("ph_tickets");
-		writer.WriteText("=");
+		writer.WriteBytes("ph_tickets="u8);
 		writer.WriteText(packet.Tickets.ToString());
 		writer.WriteByte(13);
-		writer.WriteText("photo_film");
-		writer.WriteText("=");
+		writer.WriteBytes("photo_film="u8);
 		writer.WriteText(packet.Film.ToString());
 		writer.WriteByte(13);
 	}


### PR DESCRIPTION
Avoids some encoding overhead for constant strings which I spotted while looking at RELEASE9 codegen.